### PR TITLE
Add "historic bots" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ A curated list of links and resources about bots. PRs are welcome.
 ## Analyse your Bot
 - http://www.botlytics.co/  
 
+## Historic Bots
+- http://elizagen.org/
+- http://parrynoid.org/
+- https://tools.ietf.org/html/rfc439
+
 ## Talk about Bots
 - https://www.facebook.com/groups/chatbot/  
 - https://botmakers.org/


### PR DESCRIPTION
For classic very early Internet bots, before the bot explosion. RFC 439 dates from 1973, and the PARRY and ELIZA references point to historic (and runnable) code.

Closes #3 .
