### PR TITLE
removed www.botpages.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@
 
 ## List a Bot
 - https://thereisabotforthat.com/
-- https://botlist.co/  
-- https://www.botpages.com/  
+- https://botlist.co/
 - http://www.slackbotlist.com/  
 - https://slack.com/apps  
 - https://botarena.co/  


### PR DESCRIPTION
https://www.botpages.com/ is dead.
If you try to go to http://www.botpages.com/ it redirects to https://www.geos.org/
https://www.geos.org/ is locked behind username/password combo.

So this is a dead link.